### PR TITLE
CONTRIB-4187 - added missing mandatory function define_restore_log_rules

### DIFF
--- a/backup/moodle2/restore_journal_activity_task.class.php
+++ b/backup/moodle2/restore_journal_activity_task.class.php
@@ -32,4 +32,17 @@ class restore_journal_activity_task extends restore_activity_task {
         return $rules;
 
     }
+
+    static public function define_restore_log_rules() {
+
+        $rules = array();
+        $rules[] = new restore_log_rule('journal', 'view', 'view.php?id={course_module}', '{journal}');
+        $rules[] = new restore_log_rule('journal', 'view all', 'index.php?id={course_module}', '{journal}');
+        $rules[] = new restore_log_rule('journal', 'view responses', 'report.php?id={course_module}', '{journal}');
+        $rules[] = new restore_log_rule('journal', 'add entry', 'edit.php?id={course_module}', '{journal}');
+        $rules[] = new restore_log_rule('journal', 'update entry', 'edit.php?id={course_module}', '{journal}');
+        $rules[] = new restore_log_rule('journal', 'update feedback', 'report.php?id={course_module}', '{journal}');
+
+        return $rules;
+    }
 }


### PR DESCRIPTION
The error is launched when trying to import a course backup containing mod_journal activities.

Fixes CONTRIB-4187 adding missing rules.
