### PR TITLE
Fixed class not found error

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -33,5 +33,5 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright  2016 David Monllao {@link http://www.davidmonllao.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class activity extends \core_search\base_activity {
+class activity extends \core_search\area\base_activity {
 }

--- a/classes/search/entry.php
+++ b/classes/search/entry.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot . '/mod/journal/lib.php');
  * @copyright  2016 David Monllao {@link http://www.davidmonllao.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class entry extends \core_search\base_mod {
+class entry extends \core_search\area\base_mod {
 
     /**
      * Returns recordset containing required data for indexing journal entries.


### PR DESCRIPTION
The following error appears trying to upgrade to last version:

```
Fatal error: Class 'core_search\base_activity' not found in /dades/agora/html/moodle2/mod/journal/classes/search/activity.php on line 36
Call Stack
#	Time	Memory	Function	Location
1	0.0007	239504	{main}( )	.../index.php:0
2	0.2058	6250432	admin_get_root( )	.../index.php:814
3	0.5552	9369264	require( '/dades/agora/html/moodle2/admin/settings/plugins.php' )	.../adminlib.php:7279
4	2.2470	15227672	core_search\manager::get_search_areas_list( )	.../plugins.php:537
5	2.4250	15807288	core_component::get_component_classes_in_namespace( )	.../manager.php:236
6	2.4260	15956648	class_exists ( )	.../component.php:942
7	2.4260	15956944	spl_autoload_call ( )	.../component.php:942
8	2.4260	15956992	core_component::classloader( )	.../component.php:942
9	2.4295	15958704	include_once( '/dades/agora/html/moodle2/mod/journal/classes/search/activity.php' )	.../component.php:96
```

