### PR TITLE
Fix deprecated get_all_user_name_fields() from cron_task.php

### DIFF
--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -55,7 +55,7 @@ class cron_task extends \core\task\scheduled_task {
         if ($entries = journal_get_unmailed_graded($cutofftime)) {
             $timenow = time();
 
-            $usernamefields = get_all_user_name_fields();
+            $usernamefields = \core_user\fields::get_name_fields();
             $requireduserfields = 'id, auth, mnethostid, email, mailformat, maildisplay, lang, deleted, suspended, '
                     .implode(', ', $usernamefields);
 


### PR DESCRIPTION
Since moodle 3.11 the function get_all_user_name_fields() was deprecated and is now in deprecatedlib.php, i suggest to use the new /core_user/fields API instead in "mod/journal/classes/task/cron_task.php"
See an example here: https://github.com/catalyst/moodle-mod_facetoface/issues/63 