### PR TITLE
Error with double quotes on PostgreSQL

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -577,7 +577,7 @@ function journal_update_grades($journal=null, $userid=0, $nullifnone=true) {
                 FROM {course_modules} cm
                 JOIN {modules} m ON m.id = cm.module
                 JOIN {journal} j ON cm.instance = j.id
-                WHERE m.name = "journal"';
+                WHERE m.name = \'journal\'';
         if ($recordset = $DB->get_records_sql($sql)) {
             foreach ($recordset as $journal) {
                 if ($journal->grade != false) {
@@ -793,7 +793,7 @@ function journal_get_coursemodule($journalid) {
 
     return $DB->get_record_sql('SELECT cm.id FROM {course_modules} cm
                                 JOIN {modules} m ON m.id = cm.module
-                                WHERE cm.instance = ? AND m.name = "journal"', array($journalid));
+                                WHERE cm.instance = ? AND m.name = \'journal\'', array($journalid));
 }
 
 


### PR DESCRIPTION
I've read this message from Hiroto Kagotani on the [plugin database comments](https://moodle.org/plugins/mod_journal)

> Hi, thank you very much for this very useful plugin.
> Version 2022083000 does not work with PostgreSQL since 'journal' has been quoted by "(double quotes)" in lib.php.
> Workaround is replacing " with \'.
> Thanks again.

and I bring that here just in case you missed it.