### PR TITLE
'core_user\fields' not found error in Moodle 3.9 cron job.

### DIFF
--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -55,7 +55,11 @@ class cron_task extends \core\task\scheduled_task {
         if ($entries = journal_get_unmailed_graded($cutofftime)) {
             $timenow = time();
 
-            $usernamefields = \core_user\fields::get_name_fields();
+            if (class_exists('\core_user\fields')) {
+                $usernamefields = \core_user\fields::get_name_fields();
+            } else {
+                $usernamefields = get_all_user_name_fields();
+            }
             $requireduserfields = 'id, auth, mnethostid, email, mailformat, maildisplay, lang, deleted, suspended, '
                     .implode(', ', $usernamefields);
 


### PR DESCRIPTION
Since mod_journal Release 4.0 should be still compatible with Moodle 3.9 as said in the plugin page, the existence of \core_user\fields class should be checked before using it.
This can be safely reverted after EOL of 3.9.