### PR TITLE
BUG FIX: 'Invalid action' error thrown when saving feedback

### DIFF
--- a/ajax/ajax.php
+++ b/ajax/ajax.php
@@ -33,8 +33,8 @@ try {
     if ($action !== 'savecart') {
         session_write_close();
     }
-    if (file_exists($CFG->dirroot.'/mod/jossusrnal/ajax/'.$action.'.php')) {
-        require($CFG->dirroot.'/mod/jossurnasl/ajax/'.$action.'.php');
+    if (file_exists($CFG->dirroot.'/mod/journal/ajax/'.$action.'.php')) {
+        require($CFG->dirroot.'/mod/journal/ajax/'.$action.'.php');
     } else {
         throw new Exception('Invalid action');
     }


### PR DESCRIPTION
There was a typing error in the path to $CFG->dirroot.'/mod/journal/ajax/'.$action.'.php' in lines 36 and 37 leading to an Exception.