### PR TITLE
Fix require_once call to Moodle externallib.php

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once('$CFG->libdir/externallib.php');
+require_once("$CFG->libdir/externallib.php");
 
 /**
  * The mod_journal_external class.


### PR DESCRIPTION
Just a simple fix when requiring the Moodle externallib.php library. In this particular case, using single quotes does not parse the PHP variable _$CFG->libdir_ in the string.