### PR TITLE
fix #120 wrong namespace for html_writer

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use core\output\html_writer;
-
 /**
  * Given an object containing all the necessary data,
  * (defined by the form in mod.html) this function


### PR DESCRIPTION
the plugin is currently broken on Moodle below 4.5, this patch corrects that.

the `use` statement references the wrong namespace for Moodle <4.5, and is not needed anyway as lib.php is not using a class.

removing the line works on all versions of Moodle.