### PR TITLE
MBS-10135: fix open date when using course format weeks

### DIFF
--- a/view.php
+++ b/view.php
@@ -91,7 +91,9 @@ if ($entriesmanager) {
 // Determine time constraints for journal editing.
 $timenow = time();
 if ($course->format == 'weeks' && $journal->days) {
-    $timestart = $course->startdate + (($cm->section - 1) * 604800);
+    $modinfo = get_fast_modinfo($course);
+    $sectionnum = $modinfo->get_section_info_by_id($cm->section)->sectionnum;
+    $timestart = $course->startdate + (($sectionnum - 1) * 604800);
     $timefinish = $timestart + (3600 * 24 * $journal->days);
 } else {
     $timestart = $timenow - 1;


### PR DESCRIPTION
If a journal with a day available is used in a section of a course with weeks format, the open date is calculated incorrectly.

**Testing Steps**

-  Create a course in weekly format with start date yesterday.
-  Create a journal with "Days available" = 7 days in a future section
-  Call up the journal => the message appears: "This journal won't be open until" with a wrong date.

![grafik](https://github.com/user-attachments/assets/d171eccc-3f59-4fb3-bfbb-116b16a8e190)
