### PR TITLE
fix issue #125 - Duplicated activity intro text

### DIFF
--- a/view.php
+++ b/view.php
@@ -62,11 +62,6 @@ if ($CFG->branch < 400) {
     echo $OUTPUT->heading($journalname);
 }
 
-// Display journal introduction if available.
-if (!empty($journal->intro)) {
-    echo $OUTPUT->box(format_module_intro('journal', $journal, $cm->id), 'generalbox', 'intro');
-}
-
 // Handle groups and group restrictions.
 $groupmode = groups_get_activity_groupmode($cm);
 $currentgroup = groups_get_activity_group($cm, true);


### PR DESCRIPTION
At view.php, the intro is already shown in the module description by $OUTPUT->header() , so there is no need of explicitly outputting it.