### PR TITLE
Add student filter to journal review page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This pull request adds a student filter to the journal review page, allowing teachers to easily display only those students who have submitted entries in the journal. The filter retrieves users who have entries in the journal_entries table, improving the review process by focusing on relevant submissions. The change includes modifications to report.php to implement this filtering logic, ensuring that only users with journal entries are shown in the dropdown. This update enhances the user experience by reducing clutter and making it more efficient for teachers to manage and review student submissions.
+
+## Already MERGED
 
 ![Build Status](https://github.com//elearningsoftware/moodle-mod_journal/workflows/Moodle%20Plugin%20CI/badge.svg?branch=master)
 


### PR DESCRIPTION
This update adds a student filter to the journal review page, allowing teachers to display only students with submitted entries. Modifications to report.php implement the filtering logic for improved user experience.