### PR TITLE
Fix notification user fields for Moodle 5.2, declare 5.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -31,6 +31,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: 8.4
+            moodle-branch: MOODLE_502_STABLE
+            database: pgsql
+          - php: 8.4
+            moodle-branch: MOODLE_502_STABLE
+            database: mariadb
+          - php: 8.3
+            moodle-branch: MOODLE_502_STABLE
+            database: pgsql
+          - php: 8.3
+            moodle-branch: MOODLE_502_STABLE
+            database: mariadb
           - php: 8.4
             moodle-branch: MOODLE_501_STABLE
             database: pgsql

--- a/classes/event_observer.php
+++ b/classes/event_observer.php
@@ -62,7 +62,11 @@ class event_observer {
 
         // Changed from get_users_by_capability to get_enrolled_users to prevent site admins
         // receiving notifications unless they are explicitly enrolled in the course.
-        $teachers = get_enrolled_users($context, 'mod/journal:manageentries', 0, 'u.id, u.email, u.lang, ' . $userfields);
+        // message_send() requires auth, suspended, deleted and emailstop on the recipient,
+        // and email_to_user() reads username, mailformat, maildisplay and mnethostid.
+        $requiredfields = 'u.id, u.auth, u.mnethostid, u.username, u.email, u.emailstop, '
+            . 'u.mailformat, u.maildisplay, u.lang, u.deleted, u.suspended';
+        $teachers = get_enrolled_users($context, 'mod/journal:manageentries', 0, $requiredfields . ', ' . $userfields);
 
         if (empty($teachers)) {
             return;

--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -62,8 +62,9 @@ class cron_task extends \core\task\scheduled_task {
             } else {
                 $usernamefields = get_all_user_name_fields();
             }
-            $requireduserfields = 'id, auth, mnethostid, email, emailstop, mailformat, maildisplay, lang, deleted, suspended, '
-                . implode(', ', $usernamefields);
+            // Since Moodle 5.0, email_to_user() also reads username for its log context.
+            $requireduserfields = 'id, auth, mnethostid, username, email, emailstop, mailformat, maildisplay, '
+                . 'lang, deleted, suspended, ' . implode(', ', $usernamefields);
 
             // To save some db queries.
             $users = [];

--- a/version.php
+++ b/version.php
@@ -25,7 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_journal';
-$plugin->version = 2026030700;
+$plugin->version = 2026071700;
 $plugin->requires = 2022041900;  /* Moodle 4.0 */
-$plugin->release = '5.1.3 (Build: 2026030700)';
+$plugin->supported = [400, 502]; /* Moodle 4.0 - 5.2 */
+$plugin->release = '5.1.4 (Build: 2026071700)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
- event_observer: fetch auth, suspended, deleted, emailstop (required by message_send()) plus username, mailformat, maildisplay, mnethostid for teacher notifications, avoiding a debugging notice and an extra DB fetch per recipient on every entry save.
- cron_task: add username to the fetched user fields; email_to_user() reads it since Moodle 5.0 and logged a PHP warning per sent email.
- Declare supported range Moodle 4.0 - 5.2 and bump to 5.1.4.
- CI: test against MOODLE_502_STABLE (PHP 8.3/8.4), postgres 16.